### PR TITLE
Fix edge case when unwrapping objects.

### DIFF
--- a/test/unit/angularjs/rails/rootWrappingSpec.js
+++ b/test/unit/angularjs/rails/rootWrappingSpec.js
@@ -24,6 +24,11 @@ describe('root wrapping', function () {
         testTransform({test: {abc: 'xyz', def: 'abc'}}, {abc: 'xyz', def: 'abc'});
     });
 
+    it('should not unwrap pluralName when object is expected', function() {
+        var data = {tests: [1, 2, 3], id: 4};
+        expect(railsRootWrapper.unwrap({data: data}, Resource, true)).toEqualData({data: data});
+    });
+
     function testTransform(wrappedData, unwrappedData) {
         expect(railsRootWrapper.wrap(unwrappedData, Resource)).toEqualData(wrappedData);
         expect(railsRootWrapper.unwrap({data: wrappedData}, Resource)).toEqualData({data: unwrappedData});

--- a/vendor/assets/javascripts/angularjs/rails/resource/resource.js
+++ b/vendor/assets/javascripts/angularjs/rails/resource/resource.js
@@ -6,10 +6,10 @@
                 result[angular.isArray(data) ? resource.config.pluralName : resource.config.name] = data;
                 return result;
             },
-            unwrap: function (response, resource) {
+            unwrap: function (response, resource, isObject) {
                 if (response.data && response.data.hasOwnProperty(resource.config.name)) {
                     response.data = response.data[resource.config.name];
-                } else if (response.data && response.data.hasOwnProperty(resource.config.pluralName)) {
+                } else if (response.data && response.data.hasOwnProperty(resource.config.pluralName) && !isObject) {
                     response.data = response.data[resource.config.pluralName];
                 }
 
@@ -114,7 +114,7 @@
                     if (value) {
                         var response = this.constructor.deserialize({data: value});
                         if (this.constructor.config.rootWrapping) {
-                            response = railsRootWrapper.unwrap(response, this.constructor);
+                            response = railsRootWrapper.unwrap(response, this.constructor, true);
                         }
                         angular.extend(this, response.data);
                     }
@@ -584,7 +584,7 @@
 
                     if (config.rootWrapping) {
                         promise = promise.then(function (response) {
-                            return railsRootWrapper.unwrap(response, config.resourceConstructor);
+                            return railsRootWrapper.unwrap(response, config.resourceConstructor, false);
                         });
                     }
 


### PR DESCRIPTION
Hi, I got a little problem this with the unwrapping logic.
It is an edge case, but I think the behavior is a little broken here.

I had a `Comment` class, with a relation called `comments`,
representing the replies to the given comment.

The behavior was the following,

```coffee
class Comment extends RailsResource
    @configure name: 'comment', url: '/comments'

foo = new Comment(id: 4, comments: [])
foo.id # undefined
```

which is not really what we want here.

I changed the unwrapping process to avoid using the plural name of the resource,
which will normally contain an array, when we are sure we want an object, like 
in the constructor of a class.