### PR TITLE
add ability to abort request

### DIFF
--- a/vendor/assets/javascripts/angularjs/rails/resource/resource.js
+++ b/vendor/assets/javascripts/angularjs/rails/resource/resource.js
@@ -541,6 +541,8 @@
                 RailsResource.$http = function (httpConfig, context, resourceConfigOverrides) {
                     var config = angular.extend(angular.copy(this.config), resourceConfigOverrides || {}),
                         resourceConstructor = config.resourceConstructor,
+                        requestCanceler = $q.defer(),
+                        httpConfig = angular.extend({timeout: requestCanceler.promise}, httpConfig),
                         promise = $q.when(httpConfig);
 
                     if (!config.skipRequestProcessing) {
@@ -608,6 +610,9 @@
                     promise = this.runInterceptorPhase('afterResponse', context, promise);
                     promise.resource = config.resourceConstructor;
                     promise.context = context;
+
+                    promise.abort = function() { return requestCanceler.resolve(); }
+
                     return promise;
                 };
 


### PR DESCRIPTION
This is implementation of https://github.com/FineLinePrototyping/angularjs-rails-resource/issues/135

@tpodom i don't think this one is clean one + i am not sure how to test this. Can you help me with that?

Testing for me seems little hard, since we need some kind of timing delay to be able to abort request, which is little hard with $httpBackend implementation.

I find this article http://endlessindirection.wordpress.com/2013/05/18/angularjs-delay-response-from-httpbackend/ of doing that, what you think?
