### PR TITLE
serialization: Add custom attribute to collection items

### DIFF
--- a/test/unit/angularjs/rails/serializationSpec.js
+++ b/test/unit/angularjs/rails/serializationSpec.js
@@ -343,6 +343,52 @@ describe('railsSerializer', function () {
                 expect(result['num_books']).toBe(2);
             });
 
+            it('should add custom attribute to collection from function', function() {
+                var result, authorWithPublisher, serializedBooks,
+                    serializer = createSerializer(function () {
+                        this.serializeWith('books', factory(function() {
+                            this.add('publisherId', function(book) {
+                                return book.publisher.id;
+                            });
+                        }));
+                    });
+                authorWithPublisher = {
+                    books: [
+                        {id: 1, publisher: {id: 3}},
+                        {id: 2, publisher: {id: 4}}
+                    ]
+                };
+                serializedBooks = [
+                    {id: 1, publisher_id: 3, publisher: {id:3}},
+                    {id: 2, publisher_id: 4, publisher: {id:4}}
+                ];
+
+                result = serializer.serialize(authorWithPublisher);
+                expect(result['books']).toEqual(serializedBooks);
+            });
+
+            it('should add custom attribute to collection from constant value', function() {
+                var result, authorWithPublisher, serializedBooks,
+                    serializer = createSerializer(function () {
+                        this.serializeWith('books', factory(function() {
+                            this.add('publisherId', 3);
+                        }));
+                    });
+                authorWithPublisher = {
+                    books: [
+                        {id: 1, publisher: {id: 3}},
+                        {id: 2, publisher: {id: 4}}
+                    ]
+                };
+                serializedBooks = [
+                    {id: 1, publisher_id: 3, publisher: {id:3}},
+                    {id: 2, publisher_id: 3, publisher: {id:4}}
+                ];
+
+                result = serializer.serialize(authorWithPublisher);
+                expect(result['books']).toEqual(serializedBooks);
+            });
+
             it('should use custom serializer for books', function () {
                 var result, serializedBooks, underscored,
                     serializer = createSerializer(function () {

--- a/vendor/assets/javascripts/angularjs/rails/resource/serialization.js
+++ b/vendor/assets/javascripts/angularjs/rails/resource/serialization.js
@@ -416,11 +416,22 @@
 
                     if (angular.isObject(result)) {
                         angular.forEach(this.customSerializedAttributes, function (value, key) {
-                            if (angular.isFunction(value)) {
-                                value = value.call(data, data);
-                            }
+                            if (angular.isArray(result)) {
+                                angular.forEach(result, function (item, index) {
+                                    var itemValue = value;
+                                    if (angular.isFunction(value)) {
+                                        itemValue = itemValue.call(item, item);
+                                    }
 
-                            self.serializeAttribute(result, key, value);
+                                    self.serializeAttribute(item, key, itemValue);
+                                });
+                            } else {
+                                if (angular.isFunction(value)) {
+                                    value = value.call(data, data);
+                                }
+
+                                self.serializeAttribute(result, key, value);
+                            }
                         });
                     }
 


### PR DESCRIPTION
Currently we can add custom attribute to single item but not to collection items.

For example, this works:

```js
this.serializeWith('book', factory(function() {
    this.add('publisherId', function(book) {
        return book.publisher.id;
    });
}));
```

But this doesn't (let's say `books` is an array):

```js
this.serializeWith('books', factory(function() {
    this.add('publisherId', function(book) {
        return book.publisher.id;
    });
}));
```

Other methods like `rename()` works with collection items and I have many use cases of `add()` with them. This pull request makes `add()` work too.