### PR TITLE
Serialization: apply custom serialization logic first

### DIFF
--- a/vendor/assets/javascripts/angularjs/rails/resource/serialization.js
+++ b/vendor/assets/javascripts/angularjs/rails/resource/serialization.js
@@ -411,7 +411,7 @@
                  * @returns {*} A new object or array that is ready for JSON serialization
                  */
                 Serializer.prototype.serialize = function (data) {
-                    var result = this.serializeValue(data),
+                    var result = angular.copy(data),
                         self = this;
 
                     if (angular.isObject(result)) {
@@ -434,6 +434,8 @@
                             }
                         });
                     }
+
+                    result = this.serializeValue(result);
 
                     return result;
                 };


### PR DESCRIPTION
This is fix for a bug appeared in #143.

Currently next setup isn't working:

A team, that have a vehicle and some members (which are mapping between position and user).
Example: Team “Foo” that rides on some Subaru car and driver Anton and navigator Andrey are assigned to sit inside it):

```coffee
@app.factory 'Team', (railsResourceFactory, railsSerializer) ->
  railsResourceFactory(
    url: teams_path(),
    name: 'team',
    serializer: railsSerializer ->
        @nestedAttribute('members');
        @resource('members', 'Member');
        @resource('vehicle', 'Vehicle')
        @add 'vehicle_id', (team) -> team.vehicle.id
        @exclude 'crew', 'vehicle'
  )

@app.factory 'Member', (railsResourceFactory, railsSerializer) ->
  railsResourceFactory(
    url: members_path(),
    name: 'member',
    serializer: railsSerializer ->
      @resource('user', 'User')
      @resource('slot', 'Slot')
      @add 'user_id', (member) -> member.user.id
      @add 'slot_id', (member) -> member.slot.id
      @exclude 'user', 'slot'
  )
```

The problem that is when serializing each `member` resources `user` and `slot` are being excluded *before* the functions provided to `add` methods are executed and `member.user` isn't present inside them. That happens only in nested resources.

This is a https://github.com/Envek/angularjs-rails-resource/commit/c0ba3c4d93f79dabf729d1f7799cb81f70249f38 with added tests. It effectively reverses the order of applying embedded and custom serializations. `add`s now executed first, everything else — afterwards.

@tpodom please review (especially tests).

/cc @shuhei @CyborgMaster