### PR TITLE
Add support to easily extendUrl for use with $http methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,26 @@ RailsResources have the following class methods available.
     * **path** {string} (optional) - A path to append to the resource's URL.
     * **returns** {string} - The resource URL
 
+* $extendUrl(context, path) - Appends the path if provied, then applies context to url. Does not modify Resource url.
+    * **context** {*} - The context to use when building the url.  See [Resource URLs](#resource-urls) above for more information.
+    * **path** {string} (optional) - A path to append to the resource's URL.
+    * **returns** {string} - The resource URL
+###### Ex:
+```
+angular.module("app.models").factory  "User", [ 'RailsResource',( RailsResource ) ->
+  class User extends RailsResource
+    @configure url: '/users', name: "users"
+
+    constructor: ->
+
+    @byPlatformId: ( data ) ->
+      url = @$extendUrl(data, '/{{id}}/platform/{{platform_id}}')
+      ## if data = {id: 23, platform_id:159}
+      ## url will be: /users/23/platform/159
+      return @$get(url)
+]
+
+```
 * query(queryParams, context) - Executes a GET request against the resource's base url (e.g. /books).
     * **query params** {object} (optional) - An map of strings or objects that are passed to $http to be turned into query parameters
     * **context** {*} (optional) - A context object that is used during url evaluation to resolve expression variables

--- a/vendor/assets/javascripts/angularjs/rails/resource/resource.js
+++ b/vendor/assets/javascripts/angularjs/rails/resource/resource.js
@@ -678,6 +678,39 @@
 
                     return appendPath(this.buildUrl(context || {}), path);
                 };
+                
+                /**
+                 * Allows you append a path to the resource url, and then have the context data interpolated.
+                 * 
+                 * Ex: 
+                 * If the resource url is   /users and you want to know the platform products that this users owns.
+                 * The url would be /users/23/platforms/159/products
+                 * So the pattern would be: /users/{{id}}/platforms/{{platform_id}}/products
+                 *  
+                 * ```
+                 *  data = { id: 23, platform_id : 159}
+                 *  url = $extendUrl(data, "/platforms/{{platform_id}}/products")
+                 * ``` 
+                 *  url would now equal: /users/23/platforms/159/products
+                 *  
+                 *  Now you can use that url with any of the http methods  $get, $post, $post, $delet (url)
+                 * @param context
+                 * @param path {string} (optional) An additional path to append to the URL
+                 * @return {string}
+                 */
+                RailsResource.$extendUrl = RailsResource.resourceUrl = function (context, path) {
+                    if (!angular.isObject(context)) {
+                        context = {id: context};
+                    }
+
+                    var config = {
+                        url : appendPath(this.$url(), path)
+                    };
+
+                    builder = railsUrlBuilder(config);
+
+                    return builder(context || {});
+                };
 
                 RailsResource.$get = function (url, queryParams) {
                     return this.$http(angular.extend({method: 'get', url: url}, this.getHttpConfig(queryParams)));


### PR DESCRIPTION
### Story
As a developer I should be able to easily add custom methods to a model factory.

### Problem
Currently the package does not provide a simple method that allows me to append a pattern to the resource url and then pass context data to it, so that I can then perform http actions against this modified url.

### Solution

Given a coffee class that extends RailsResource, I can easily add intuitive helper methods to retrieve custom data.

###### Ex:
```
angular.module("app.models").factory  "User", [ 'RailsResource', ( RailsResource ) ->
  class User extends RailsResource
    @configure url: '/users', name: "users"

    @platform: ( data ) ->
      url = @$extendUrl(data, '/platforms/{{platform_id}}')
      return @$get(url)

]

```

### Usage

```
sgApp.controller( 'PlatformsEditCtrl', [
    '$scope', '$stateParams','User',
    ($scope, $stateParams, User) ->
      
       
      #Define success callback
      onSuccess = (response)->
        if(response.data)
          $scope.platform = response.data

      # Make API call
      User.platform( { id:23, platform_id : 159 }, onSuccess)
])
```