### PR TITLE
README: always call @configure() in subclasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ class Encyclopedia extends Book
   @configure url: '/encyclopedias', name: 'encyclopedia'
 ````
 
+**NOTE:** Always call <code>@configure()</code> in subclasses, even when no configuration is required.
+This is important to prevent overriding the parent's configuration with interceptors, etc (especially when using a module mixin pattern).
+
 ##### JavaScript
 Since the purpose of exposing the RailsResource was to allow for CoffeeScript users to create classes from it the JavaScript way
 is basically just the same as the generated CoffeeScript code.  The <code>RailsResource.extendTo</code> function is a modification
@@ -126,7 +129,7 @@ Resource.configure(config);
 angular.module('book.controllers').controller('BookShelfCtrl', ['$scope', 'Book', function ($scope, Book) {
     $scope.searching = true;
     $scope.books = [];
-    
+
     // Find all books matching the title
     Book.query({ title: title }).then(function (results) {
         $scope.books = results;


### PR DESCRIPTION
TL;DR I fought with this problem for quite a while until figuring it out, this README note would have saved precious time.

In this example:

```coffeescript
class Book extends RailsResource
  @configure url: '/books', name: 'book'

class Encyclopedia extends Book
  @interceptAfterResponse (result) ->
    ...

class StoryBook extends Book
```

The class `StoryBook` will also have the after response interceptor, since `Encyclopedia` added the interceptor to `Book`'s config object.

Calling `@configure` on `StoryBook` will even be worse, making the load order decide whether or not it will have the interceptor.

Calling `@configure()` in every subclass of `RailsResource` (including sub-subclass) before creating any interceptors (or other `@config` changes) will prevent this, since `@configure` copies the current `@config` on every run.

Unless there is a way to call `@configure()` on each extend automatically (of every type), this PR just adds a note to the README.