### PR TITLE
Add option to specify a singular resource.

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ defined on the resource can be called multiple times to adjust properties as nee
  * **updateMethod** *(optional)* - Allows overriding the default HTTP method (PUT) used for update.  Valid values are "post", "put", or "patch".
  * **serializer** *(optional)* - Allows specifying a custom [serializer](#serializers) to configure custom serialization options.
  * **fullResponse** *(optional)* - When set to true promises will return full $http responses instead of just the response data.
+ * **singular** - (Default: false) Treat this as a [singular resource](http://guides.rubyonrails.org/routing.html#singular-resources).
  * **interceptors** *(optional)* - See [Interceptors](#interceptors)
  * **extensions** *(optional)* - See [Extensions](#extensions)
 

--- a/test/unit/angularjs/rails/utils/urlBuilderSpec.js
+++ b/test/unit/angularjs/rails/utils/urlBuilderSpec.js
@@ -22,6 +22,13 @@ describe("railsUrlBuilder", function () {
         })({id: 1})).toEqualData('/books/1');
     }));
 
+    it('should not append id when singular', inject(function (railsUrlBuilder) {
+        expect(railsUrlBuilder({
+          url: '/book',
+          singular: true
+        })()).toEqualData('/book');
+    }));
+
     it('should use author id for book list', inject(function (railsUrlBuilder) {
         expect(railsUrlBuilder({
           url: '/authors/{{authorId}}/books/{{id}}',

--- a/vendor/assets/javascripts/angularjs/rails/resource/resource.js
+++ b/vendor/assets/javascripts/angularjs/rails/resource/resource.js
@@ -26,6 +26,7 @@
             defaultParams: undefined,
             underscoreParams: true,
             fullResponse: false,
+            singular: false,
             extensions: []
         };
 

--- a/vendor/assets/javascripts/angularjs/rails/resource/utils/url_builder.js
+++ b/vendor/assets/javascripts/angularjs/rails/resource/utils/url_builder.js
@@ -39,7 +39,7 @@
                 return url;
             }
 
-            if (url.indexOf($interpolate.startSymbol()) === -1) {
+            if (!config.singular && url.indexOf($interpolate.startSymbol()) === -1) {
                 url = url + '/' + $interpolate.startSymbol() + idAttribute + $interpolate.endSymbol();
             }
 


### PR DESCRIPTION
[Singular resources](http://guides.rubyonrails.org/routing.html#singular-resources) are not
currently supported by this project.  I identified the main cause as
the auto-appending of an ID to the url.  I added an option to disable this
feature.