### PR TITLE
Allow query params for POST, PUT and PATCH

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,10 +303,11 @@ RailsResources have the following class methods available.
     * **queryParams** {object} (optional) - The set of query parameters to include in the GET request
     * **returns** {promise} A promise that will be resolved with a new Resource instance (or instances in the case of an array response).
 
-* $post/$put/$patch(customUrl, data, resourceConfigOverrides) - Serializes the data parameter using the Resource's normal serialization process and submits the result as a POST / PUT / PATCH to the given URL.
+* $post/$put/$patch(customUrl, data, resourceConfigOverrides, queryParams) - Serializes the data parameter using the Resource's normal serialization process and submits the result as a POST / PUT / PATCH to the given URL.
     * **customUrl** {string} - The url to POST / PUT / PATCH to
     * **data** {object} - The data to serialize and POST / PUT / PATCH
     * **resourceConfigOverrides** {object} (optional) - An optional set of RailsResource configuration option overrides to use for this request. Root wrapping and serialization for the request data can be bypassed using the `skipRequestProcessing` flag. This also bypasses the entire pre-request [interceptor](#interceptors) chain.
+    * **queryParams** {object} (optional) - The set of query parameters to include in the request
     * **returns** {promise} A promise that will be resolved with a new Resource instance (or instances in the case of an array response).
 
 * $delete(customUrl, queryParams) - Executes a DELETE to a custom URL.  The main difference between this and $http.delete is that a server response that contains a body will be deserialized using the normal Resource deserialization process.
@@ -375,8 +376,10 @@ All of the instance methods will update the instance in-place on response and wi
 
 * $http(httpConfig, resourceConfigOverrides) - Executes class method $http with the resource instance as the operation context.
 
-* $post(customUrl), $put(customUrl), $patch(customUrl) - Serializes and submits the instance using an HTTP POST/PUT/PATCH to the given URL.
+* $post(customUrl, context, queryParams), $put(customUrl, context, queryParams), $patch(customUrl, context, queryParams) - Serializes and submits the instance using an HTTP POST/PUT/PATCH to the given URL.
     * **customUrl** {string} - The url to POST / PUT / PATCH to
+    * **context** {object} - The instance that the operation is being run against.
+    * **queryParams** {object} (optional) - The set of query parameters to include in the POST / PUT / PATCH request
     * **returns** {promise} - A promise that will be resolved with the instance itself
 
 * $delete(customUrl, queryParams) - Executes a DELETE to a custom URL.  The main difference between this and $http.delete is that a server response that contains a body will be deserialized using the normal Resource deserialization process.

--- a/test/unit/angularjs/rails/resourceSpec.js
+++ b/test/unit/angularjs/rails/resourceSpec.js
@@ -484,6 +484,19 @@ describe('railsResourceFactory', function () {
                 expect(result).toEqualData({id: 123, abc: 'xyz', xyz: 'abc', extra: 'test'});
             });
 
+            it('should be able to ' + method + ' to arbitrary url with query params', function () {
+                var promise, result = {};
+
+                promise = Test['$' + method]('/xyz', {abc: 'xyz', xyz: 'abc'}, {}, {def: 'ghi'});
+                $httpBackend['expect' + angular.uppercase(method)]('/xyz?def=ghi', {test: {abc: 'xyz', xyz: 'abc'}}).respond(200, {test: {abc: 'xyz', xyz: 'abc', extra: 'test'}});
+
+                promise.then(function (response) {
+                    result = response;
+                });
+
+                $httpBackend.flush();
+            });
+
             it('should be able to ' + method + ' instance to arbitrary url', function () {
                 var test = new Test({id: 123, abc: 'xyz', xyz: 'abc'});
                 $httpBackend['expect' + angular.uppercase(method)]('/xyz', {test: {id: 123, abc: 'xyz', xyz: 'abc'}}).respond(200, {test: {id: 123, abc: 'xyz', xyz: 'abc', extra: 'test'}});
@@ -492,6 +505,13 @@ describe('railsResourceFactory', function () {
 
                 // abc was originally set on the object so it should still be there after the update
                 expect(test).toEqualData({id: 123, abc: 'xyz', xyz: 'abc', extra: 'test'});
+            });
+
+            it('should be able to ' + method + ' instance to arbitrary url with query params', function () {
+                var test = new Test({abc: 'xyz', xyz: 'abc'});
+                $httpBackend['expect' + angular.uppercase(method)]('/xyz?def=ghi', {test: {abc: 'xyz', xyz: 'abc'}}).respond(200, {test: {abc: 'xyz', xyz: 'abc', extra: 'test'}});
+                test['$' + method]('/xyz', {}, {def: 'ghi'});
+                $httpBackend.flush();
             });
         });
 

--- a/vendor/assets/javascripts/angularjs/rails/resource/resource.js
+++ b/vendor/assets/javascripts/angularjs/rails/resource/resource.js
@@ -720,17 +720,16 @@
                 };
 
                 angular.forEach(['post', 'put', 'patch'], function (method) {
-                    RailsResource['$' + method] = function (url, data, resourceConfigOverrides) {
+                    RailsResource['$' + method] = function (url, data, resourceConfigOverrides, queryParams) {
                         // clone so we can manipulate w/o modifying the actual instance
                         data = angular.copy(data);
-                        return this.$http(angular.extend({method: method, url: url, data: data}, this.getHttpConfig()), null, resourceConfigOverrides);
+                        return this.$http(angular.extend({method: method, url: url, data: data}, this.getHttpConfig(queryParams)), null, resourceConfigOverrides);
                     };
 
-                    RailsResource.prototype['$' + method] = function (url) {
+                    RailsResource.prototype['$' + method] = function (url, context, queryParams) {
                         // clone so we can manipulate w/o modifying the actual instance
                         var data = angular.copy(this, {});
-                        return this.constructor.$http(angular.extend({method: method, url: url, data: data}, this.constructor.getHttpConfig()), this);
-
+                        return this.constructor.$http(angular.extend({method: method, url: url, data: data}, this.constructor.getHttpConfig(queryParams)), this);
                     };
                 });
 


### PR DESCRIPTION
## Motivation ##

In our custom system we implemented a generic way to filter properties of resources by passing query params. This works well for all methods where we we can pass those query params, but not for $post, $put or $patch when returning the created or updated resource.

These filter properties should not be send within the request body, since the are not part of the resource, but describing some kind of meta information how the response should look like.

## Implementation ##

Like already implemented for $delete, I added query params for $post, $put and $patch as well. I updated the readme and wrote tests to check, that query parameters are appended correctly.

## Usage ##

$post as Class Member
```
var url = '/test';
var params = {abc: def};
Resource.$post(url, {}, {}, params); // results in POST /test?abc=def
```

$post on Instance
```
var url = '/test/{id}';
var params = {abc: def};
var test = new Test({id: 123});
test.$post('/test', {}, params); // results in POST /test/123?abc=def
```