### PR TITLE
Change angular dependency from 1.0.x to 1.x.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/FineLinePrototyping/dist-angularjs-rails-resource.git"
   },
   "dependencies": {
-    "angular": "~1.0"
+    "angular": "^1.0"
   },
   "ignore": [
     "node_modules",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "resources"
   ],
   "dependencies": {
-    "angular": "~1.0"
+    "angular": "^1.0"
   },
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
According to [node-semvar](https://github.com/npm/node-semver):

- `~1.0` means `>=1.0.0 <1.1.0`
- `^1.0` means `>=1.0.0 <2.0.0`

`angular` dependency should be `^1.0`.

After https://github.com/FineLinePrototyping/angularjs-rails-resource/commit/1741a0d2350ab39e20c69b54bccc25262ead6a6a, npm and bower are unnecessarily installing `angular` 1.0.8.