### PR TITLE
fixed bug where idAttribute wasn't correctly used to interpolate url

### DIFF
--- a/vendor/assets/javascripts/angularjs/rails/resource/resource.js
+++ b/vendor/assets/javascripts/angularjs/rails/resource/resource.js
@@ -674,13 +674,14 @@
                  * @param path {string} (optional) An additional path to append to the URL
                  * @return {string}
                  */
-                RailsResource.$url = RailsResource.resourceUrl = function (context, path) {
-                    if (!angular.isObject(context)) {
-                        context = {id: context};
-                    }
+                 RailsResource.$url = RailsResource.resourceUrl = function (ctxt, path) {
+                     if (!angular.isObject(ctxt)) {
+                         context = {};
+                         context[this.config.idAttribute] = ctxt;
+                     }
 
-                    return appendPath(this.buildUrl(context || {}), path);
-                };
+                     return appendPath(this.buildUrl(context || {}), path);
+                 };
 
                 RailsResource.$get = function (url, queryParams) {
                     return this.$http(angular.extend({method: 'get', url: url}, this.getHttpConfig(queryParams)));


### PR DESCRIPTION
The `idAttribute` wasn't properly used before when interpolating URL strings. There was a line of code that inserted a hard-coded attribute named `id` into the params object used for interpolation, leading to wrong behavior if you wanted to used an `idAttribute` with a name other than `id`.