### PR TITLE
Some ES6 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,73 @@ function Resource() {
 RailsResource.extendTo(Resource);
 Resource.configure(config);
 ````
+##### ES6
+The code currently does not export any module information but it can be imported using the 'load with side-effects' method.
+This efectively runs through the code and makes the whole module available. Because we don't have an export to assign 
+the name 'rails' to a variable, we call in the angular module as a string, for example :
+````javascript
+// Import angular
+import angular                  from 'angular';
+import 'angular-animate'
+import 'angular-aria'
+// Materail Design lib
+import material                 from 'angular-material';
+// Router
+import angularUIRouter          from 'angular-ui-router';
+import ngTokenAuth              from 'ng-token-auth';
+// Note no 'from'
+import  'angularjs-rails-resource';
+
+import Configurations           from './configuration/module';
+import SignIn                   from './devise/signIn/module';
+import Models                   from './model/module';
+
+const testAppModule = angular.module( 'testApp',
+    [   material,
+        ngTokenAuth,
+        ngStorage.name,
+        angularUIRouter,
+        'rails'
+        ])
+````
+If you use ES6 classes to set up the model, the railsResourceFactory should be returned from the constructor, for example :
+
+````javascript
+class Client {
+    constructor(railsResourceFactory,){
+        return railsResourceFactory({
+            url: "/clients",
+            name: "client"
+        });
+    }
+    clientMethod1(){
+        
+    };
+    
+    clientMethod2(){
+        
+    };
+
+}
+
+Client.$inject = ['railsResourceFactory'];
+
+export default Client
+````
+The model classes can then be gathered up in a separate module.js or index.js file, for example :
+````javascript
+
+import Client               from './Client'
+import User                 from './User'
+import Blog                 from './Blog'
+
+export default angular
+    .module('model', [])
+    .service('Client', Client)
+    .service('User', User)
+    .service('Blog', Blog)
+````
+
 
 ### Using Resources
 ```javascript
@@ -153,7 +220,7 @@ angular.module('book.controllers').controller('BookShelfCtrl', ['$scope', 'Book'
     }).create();
 }]);
 ```
-
+The 
 ### Custom Serialization
 When defining a resource, you can pass a custom [serializer](#serializers) using the <code>serializer</code> configuration option to
 alter the behavior of the object serialization.


### PR DESCRIPTION
It took me a while to figure out how to use this library in an ES6 module/classes type way. I've written a little addition to the documentation to explain how I did it. Note I've tried to leave in some real code in the examples as I find context really helps people understand what is going on (so the doco is a little longer because of that).

Beyond that, you might consider two further things :
1. It would be great if the code exported a name for itself. Something along these lines at the very start would work :
if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.exports === exports) {
  module.exports = 'rails';
}

That would allow the module to be imported as:
import rails from '...'

2. Make the RailsResource base class available to an ES6 extends call. I have a feeling it is very close but I couldn't get it to work. 

Beyond that again, thanks for a great module, it really helped me when I first went to do an angular/rails type project.
C