### PR TITLE
Allow query params for create, update, and save

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,13 +435,13 @@ All of the instance methods will update the instance in-place on response and wi
 * get() - Refreshes the instance from the server.
     * **returns** {promise} - A promise that will be resolved with the instance itself
 
-* create() - Submits the resource instance to the resource's base URL (e.g. /books) using a POST
+* create(queryParams) - Submits the resource instance to the resource's base URL (e.g. /books) using a POST
     * **returns** {promise} - A promise that will be resolved with the instance itself
 
-* update() - Submits the resource instance to the resource's URL (e.g. /books/1234) using a PUT
+* update(queryParams) - Submits the resource instance to the resource's URL (e.g. /books/1234) using a PUT
     * **returns** {promise} - A promise that will be resolved with the instance itself
 
-* save() - Calls <code>create</code> if <code>isNew</code> returns true, otherwise it calls <code>update</code>.
+* save(queryParams) - Calls <code>create</code> if <code>isNew</code> returns true, otherwise it calls <code>update</code>.
 
 * remove(), delete() - Executes an HTTP DELETE against the resource's URL (e.g. /books/1234)
     * **returns** {promise} - A promise that will be resolved with the instance itself

--- a/test/unit/angularjs/rails/resourceSpec.js
+++ b/test/unit/angularjs/rails/resourceSpec.js
@@ -219,6 +219,16 @@ describe('railsResourceFactory', function () {
             expect(data).toEqualData({id: 123, abcDef: 'xyz'});
         });
 
+        it('should be able to create new instance and save it with query params', function () {
+            var data = new Test({abcDef: 'xyz'});
+
+            $httpBackend.expectPOST('/test?x=1&y=2', {test: {abc_def: 'xyz'}}).respond(200, {test: {id: 123, abc_def: 'xyz'}});
+            data.create({x: 1, y: 2});
+            $httpBackend.flush();
+
+            expect(data).toEqualData({id: 123, abcDef: 'xyz'});
+        });
+
         it("should return a promise when calling save", function () {
             var promise, data;
 
@@ -233,6 +243,16 @@ describe('railsResourceFactory', function () {
 
             $httpBackend.expectPOST('/test', {test: {abc_def: 'xyz'}}).respond(200, {test: {id: 123, abc_def: 'xyz'}});
             data.save();
+            $httpBackend.flush();
+
+            expect(data).toEqualData({id: 123, abcDef: 'xyz'});
+        });
+
+        it('should be able to create new instance and save it using save with query params', function () {
+            var data = new Test({abcDef: 'xyz'});
+
+            $httpBackend.expectPOST('/test?x=1&y=2', {test: {abc_def: 'xyz'}}).respond(200, {test: {id: 123, abc_def: 'xyz'}});
+            data.save({x: 1, y: 2});
             $httpBackend.flush();
 
             expect(data).toEqualData({id: 123, abcDef: 'xyz'});
@@ -255,7 +275,24 @@ describe('railsResourceFactory', function () {
             expect(data).toEqualData({id: 123, abcDef: 'xyz', xyz: 'abc', extra: 'test'});
         });
 
-         it('should be able to create new instance and update it using save', function () {
+        it('should be able to create new instance and update it with query params', function () {
+            var data = new Test({abcDef: 'xyz'});
+
+            $httpBackend.expectPOST('/test', {test: {abc_def: 'xyz'}}).respond(200, {test: {id: 123, abc_def: 'xyz'}});
+            data.create();
+            $httpBackend.flush(1);
+
+            expect(data).toEqualData({id: 123, abcDef: 'xyz'});
+
+            $httpBackend.expectPUT('/test/123?x=1&y=2', {test: {abc_def: 'xyz', id: 123, xyz: 'abc'}}).respond(200, {test: {id: 123, abc_def: 'xyz', xyz: 'abc', extra: 'test'}});
+            data.xyz = 'abc';
+            data.update({x: 1, y: 2});
+            $httpBackend.flush();
+
+            expect(data).toEqualData({id: 123, abcDef: 'xyz', xyz: 'abc', extra: 'test'});
+        });
+
+        it('should be able to create new instance and update it using save', function () {
             var data = new Test({abcDef: 'xyz'});
 
             $httpBackend.expectPOST('/test', {test: {abc_def: 'xyz'}}).respond(200, {test: {id: 123, abc_def: 'xyz'}});
@@ -267,6 +304,23 @@ describe('railsResourceFactory', function () {
             $httpBackend.expectPUT('/test/123', {test: {abc_def: 'xyz', id: 123, xyz: 'abc'}}).respond(200, {test: {id: 123, abc_def: 'xyz', xyz: 'abc', extra: 'test'}});
             data.xyz = 'abc';
             data.save();
+            $httpBackend.flush();
+
+            expect(data).toEqualData({id: 123, abcDef: 'xyz', xyz: 'abc', extra: 'test'});
+        });
+
+        it('should be able to create new instance and update it using save with query params', function () {
+            var data = new Test({abcDef: 'xyz'});
+
+            $httpBackend.expectPOST('/test', {test: {abc_def: 'xyz'}}).respond(200, {test: {id: 123, abc_def: 'xyz'}});
+            data.save();
+            $httpBackend.flush(1);
+
+            expect(data).toEqualData({id: 123, abcDef: 'xyz'});
+
+            $httpBackend.expectPUT('/test/123?x=1&y=2', {test: {abc_def: 'xyz', id: 123, xyz: 'abc'}}).respond(200, {test: {id: 123, abc_def: 'xyz', xyz: 'abc', extra: 'test'}});
+            data.xyz = 'abc';
+            data.save({x: 1, y: 2});
             $httpBackend.flush();
 
             expect(data).toEqualData({id: 123, abcDef: 'xyz', xyz: 'abc', extra: 'test'});

--- a/vendor/assets/javascripts/angularjs/rails/resource/resource.js
+++ b/vendor/assets/javascripts/angularjs/rails/resource/resource.js
@@ -736,12 +736,12 @@
                     };
                 });
 
-                RailsResource.prototype.create = function () {
-                    return this.$post(this.$url(), this);
+                RailsResource.prototype.create = function (queryParams) {
+                    return this.$post(this.$url(), this, queryParams);
                 };
 
-                RailsResource.prototype.update = function () {
-                    return this['$' + this.constructor.config.updateMethod](this.$url(), this);
+                RailsResource.prototype.update = function (queryParams) {
+                    return this['$' + this.constructor.config.updateMethod](this.$url(), this, queryParams);
                 };
 
                 RailsResource.prototype.get = function () {
@@ -754,11 +754,11 @@
                         this[idAttribute] === null;
                 };
 
-                RailsResource.prototype.save = function () {
+                RailsResource.prototype.save = function (queryParams) {
                     if (this.isNew()) {
-                        return this.create();
+                        return this.create(queryParams);
                     } else {
-                        return this.update();
+                        return this.update(queryParams);
                     }
                 };
 


### PR DESCRIPTION
Same as #198, but for the instance methods create, update, and save. This is pretty straight forward (motivation & usage can be seen in mentioned PR).