### PR TITLE
skip deserialize already serialized resources to prevent stack overflow

### DIFF
--- a/vendor/assets/javascripts/angularjs/rails/resource/serialization.js
+++ b/vendor/assets/javascripts/angularjs/rails/resource/serialization.js
@@ -478,6 +478,12 @@
                     return result;
                 };
 
+                var RailsResource = null;
+                function getRailsResource() {
+                    RailsResource = RailsResource || RailsResourceInjector.getDependency('RailsResource');
+                    return RailsResource;
+                }
+
                 /**
                  * Iterates over the data deserializing each entry on arrays and each key/value on objects.
                  *
@@ -497,7 +503,9 @@
                             result.push(self.deserializeData(value, Resource, triggerPhase));
                         });
                     } else if (angular.isObject(data)) {
-                        if (angular.isDate(data)) {
+                        if (angular.isDate(data) ||
+                                (Resource && data instanceof Resource) ||
+                                (!Resource && data instanceof getRailsResource())) {
                             return data;
                         }
                         result = {};


### PR DESCRIPTION
Assuming 3 resources - X, Y, and Z, if you do:

```javascript
var x = new X();
var y = new Y({ x: x });
x.y = y;
var z = new Z({ y: y });
```

You get stack overflow. I have a lot of resources that I want them to know their parents (the two sides of belongs_to & has_many), and when I supply them to a third resource in the constructor it fails, and I have to initialize the resource and then supply it in a another line which is a pain...

I'm wondering if you think that's the right way to do it